### PR TITLE
Invoke the Value class's body only once

### DIFF
--- a/lib/value.rb
+++ b/lib/value.rb
@@ -32,7 +32,7 @@ class Value < Struct
       optional_args.each_key { |arg| arguments[arg] = false }
       validate_names(*arguments.keys)
 
-      clazz = super(*arguments.keys)
+      clazz = super(*arguments.keys, &nil)
 
       # define class and instance methods in modules so that the class can
       # override them

--- a/spec/unit/value_spec.rb
+++ b/spec/unit/value_spec.rb
@@ -79,6 +79,12 @@ RSpec.describe Value do
   context "with a class body" do
     let(:value) do
       Value.new(:a) do
+        @calls = (@calls || 0) + 1
+
+        def self.calls
+          @calls
+        end
+
         def initialize(a)
           raise ArgumentError.new("not even") unless a.even?
           super
@@ -98,6 +104,10 @@ RSpec.describe Value do
       v = value.new(2)
       expect(v.a).to eq(2)
       expect(v.b).to eq(3)
+    end
+
+    it "only invokes the class body once" do
+      expect(value.calls).to eq(1)
     end
   end
 end


### PR DESCRIPTION
Prevent the initialization block from being passed to Struct.new